### PR TITLE
Pin unpinned-action references across 4 workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,14 +11,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-go@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
       with:
         go-version: "1.26.3"
     - name: Run build
       run: make build
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v9
+      uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
       with:
         version: latest
         args: --verbose
@@ -41,14 +41,14 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get install -y lua-json
     - name: Install HAProxy ${{ matrix.haproxy-version }}
-      uses: timwolla/action-install-haproxy@main
+      uses: timwolla/action-install-haproxy@47ea13d97501d5bb5ed7066e06ffa91eea697816
       id: install-haproxy
       with:
         branch: ${{ matrix.haproxy-version }}
         use_openssl: yes
         use_lua: yes
-    - uses: actions/checkout@v6
-    - uses: actions/setup-go@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
       with:
         go-version: "1.26.3"
     - name: Run integration tests on Kubernetes ${{ matrix.envtest-version }}
@@ -57,14 +57,14 @@ jobs:
     if: github.ref_name == 'master' || startsWith(github.ref_name, 'release-') ## delayed check, PRs do not have access to secrets
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: docker/login-action@v4
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+    - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
       with:
         username: jcmoraisjr
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - uses: docker/setup-qemu-action@v4
-    - uses: docker/setup-buildx-action@v4
-    - uses: docker/build-push-action@v7
+    - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
+    - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+    - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
       with:
         context: .
         file: builder/Dockerfile

--- a/.github/workflows/closeissues.yaml
+++ b/.github/workflows/closeissues.yaml
@@ -6,7 +6,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v10
+    - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue got stale and will be closed in 7 days.'

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -23,19 +23,19 @@ jobs:
         )
         echo "GIT_TAG=$GIT_TAG" >> $GITHUB_ENV
         echo "TAGS=$TAGS" >> $GITHUB_ENV
-    - uses: actions/checkout@v6
-    - uses: docker/login-action@v4
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+    - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
       with:
         username: jcmoraisjr
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - uses: docker/login-action@v4
+    - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_TOKEN }}
-    - uses: docker/setup-qemu-action@v4
-    - uses: docker/setup-buildx-action@v4
-    - uses: docker/build-push-action@v7
+    - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
+    - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+    - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
       with:
         context: .
         file: builder/Dockerfile

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: check-spelling
         id: spelling
-        uses: check-spelling/check-spelling@v0.0.25
+        uses: check-spelling/check-spelling@c635c2f3f714eec2fcf27b643a1919b9a811ef2e
         with:
           suppress_push_for_open_pull_request: ${{ github.actor != 'dependabot[bot]' && 1 }}
           checkout: true


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

## Why these matter

**Why pin to a SHA** (`unpinned-action`)

Each unpinned action reference can be force-moved to attacker-controlled code by the action's owner or anyone who compromises their account — exactly what happened in the tj-actions/changed-files attack (CVE-2025-30066, Mar 2025). Pinning to a 40-character commit SHA freezes the exact reviewed code.

Reference: CWE-829 · [GitHub/OWASP guidance](https://docs.github.com/en/actions/reference/security/secure-use) · Real-world precedent: tj-actions/changed-files supply-chain attack (CVE-2025-30066, Mar 2025)

### `.github/workflows/build.yaml`

- 🟠 MED `golangci/golangci-lint-action` (job `build`)
- 🟠 MED `timwolla/action-install-haproxy` (job `integration`)
- 🟠 MED `docker/login-action` (job `image`)
- 🟠 MED `docker/setup-qemu-action` (job `image`)
- 🟠 MED `docker/setup-buildx-action` (job `image`)
- 🟠 MED `docker/build-push-action` (job `image`)
- ⚪ LOW `actions/checkout` (job `build`)
- ⚪ LOW `actions/setup-go` (job `build`)
- ⚪ LOW `actions/checkout` (job `integration`)
- ⚪ LOW `actions/setup-go` (job `integration`)
- ⚪ LOW `actions/checkout` (job `image`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,14 +11,14 @@
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-go@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
       with:
         go-version: "1.26.3"
     - name: Run build
       run: make build
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v9
+      uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
       with:
         version: latest
         args: --verbose
@@ -41,14 +41,14 @@
     - name: Install dependencies
       run: sudo apt-get install -y lua-json
     - name: Install HAProxy ${{ matrix.haproxy-version }}
-      uses: timwolla/action-install-haproxy@main
+      uses: timwolla/action-install-haproxy@47ea13d97501d5bb5ed7066e06ffa91eea697816
       id: install-haproxy
       with:
         branch: ${{ matrix.haproxy-version }}
         use_openssl: yes
         use_lua: yes
-    - uses: actions/checkout@v6
-    - uses: actions/setup-go@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
       with:
         go-version: "1.26.3"
     - name: Run integration tests on Kubernetes ${{ matrix.envtest-version }}
@@ -57,14 +57,14 @@
     if: github.ref_name == 'master' || startsWith(github.ref_name, 'release-') ## delayed check, PRs do not have access to secrets
... (18 more diff lines — see Files changed)
```

</details>

### `.github/workflows/closeissues.yaml`

- ⚪ LOW `actions/stale` (job `stale`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/closeissues.yaml
+++ b/.github/workflows/closeissues.yaml
@@ -6,7 +6,7 @@
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v10
+    - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue got stale and will be closed in 7 days.'
```

</details>

### `.github/workflows/image.yaml`

- 🟠 MED `docker/login-action` (job `build-image`)
- 🟠 MED `docker/login-action` (job `build-image`)
- 🟠 MED `docker/setup-qemu-action` (job `build-image`)
- 🟠 MED `docker/setup-buildx-action` (job `build-image`)
- 🟠 MED `docker/build-push-action` (job `build-image`)
- ⚪ LOW `actions/checkout` (job `build-image`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -23,19 +23,19 @@
         )
         echo "GIT_TAG=$GIT_TAG" >> $GITHUB_ENV
         echo "TAGS=$TAGS" >> $GITHUB_ENV
-    - uses: actions/checkout@v6
-    - uses: docker/login-action@v4
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+    - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
       with:
         username: jcmoraisjr
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - uses: docker/login-action@v4
+    - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_TOKEN }}
-    - uses: docker/setup-qemu-action@v4
-    - uses: docker/setup-buildx-action@v4
-    - uses: docker/build-push-action@v7
+    - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
+    - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+    - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
       with:
         context: .
         file: builder/Dockerfile
```

</details>

### `.github/workflows/spelling.yml`

- 🟠 MED `check-spelling/check-spelling` (job `spelling`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -51,7 +51,7 @@
     steps:
       - name: check-spelling
         id: spelling
-        uses: check-spelling/check-spelling@v0.0.25
+        uses: check-spelling/check-spelling@c635c2f3f714eec2fcf27b643a1919b9a811ef2e
         with:
           suppress_push_for_open_pull_request: ${{ github.actor != 'dependabot[bot]' && 1 }}
           checkout: true
```

</details>


---

_Have other repositories you'd like analysed? Request a scan at [codeopsai.com](https://codeopsai.com)._

---

_AI-generated. Review the diff before merging._
