### PR TITLE
Fix permissions-missing in closeissues.yaml

### DIFF
--- a/.github/workflows/closeissues.yaml
+++ b/.github/workflows/closeissues.yaml
@@ -5,6 +5,9 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
     - uses: actions/stale@v10
       with:


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

### 🟠 `permissions-missing` · `stale`

Job `stale` in `.github/workflows/closeissues.yaml` runs `actions/stale@v10` with `secrets.GITHUB_TOKEN`. The comprehension states this step performs GitHub API writes that require `issues: write` and `pull-requests: write`, but the job has no declared `permissions:` block, so t…

Reference: CWE-862 · [GitHub/OWASP guidance](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)

<details>
<summary>Evidence & diff</summary>

```diff
--- a/.github/workflows/closeissues.yaml
+++ b/.github/workflows/closeissues.yaml
@@ -5,6 +5,9 @@
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
     - uses: actions/stale@v10
       with:
```

</details>


---

_Have other repositories you'd like analysed? Request a scan at [codeopsai.com](https://codeopsai.com)._

---

_AI-generated. Review the diff before merging._
