### PR TITLE
Fix data race in TestHAProxyProcsLoop and enable -race flag for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,7 @@ gotestsum:
 
 .PHONY: test
 test: gotestsum
-	## fix race and add -race param
-	$(LOCAL_GOTESTSUM) --format=testname -- -tags=cgo ./pkg/...
+	$(LOCAL_GOTESTSUM) --format=testname -- -race -tags=cgo ./pkg/...
 
 .PHONY: golangci-lint
 golangci-lint:

--- a/pkg/haproxy/socket/socket_test.go
+++ b/pkg/haproxy/socket/socket_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -458,7 +459,7 @@ func TestHAProxyProcsLoop(t *testing.T) {
 		cli := &clientMock{
 			cmdError: syscall.ECONNREFUSED,
 		}
-		time.AfterFunc(test.reload, func() { cli.cmdError = nil })
+		time.AfterFunc(test.reload, func() { cli.setError(nil) })
 		start := time.Now()
 		_, err := HAProxyProcs(ctx, cli)
 		if err != nil {
@@ -493,6 +494,13 @@ type clientMock struct {
 	cmdError  error
 	callCnt   int
 	hasSock   bool
+	mutex     sync.Mutex
+}
+
+func (c *clientMock) setError(err error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.cmdError = err
 }
 
 func (c *clientMock) Address() string {
@@ -507,6 +515,8 @@ func (c *clientMock) HasConn() bool {
 }
 
 func (c *clientMock) Send(observer func(duration time.Duration), command ...string) ([]string, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	c.callCnt++
 	return c.cmdOutput, c.cmdError
 }


### PR DESCRIPTION
Add `-race` to the test target in the Makefile, and fix the data race it exposed in TestHAProxyProcsLoop by protecting `clientMock.cmdError` and `callCnt` with a mutex.