### PR TITLE
Strip managed fields from cached objects

### DIFF
--- a/pkg/controller/launch/launch.go
+++ b/pkg/controller/launch/launch.go
@@ -50,6 +50,7 @@ func Run(cfg *config.Config) error {
 		Cache: cache.Options{
 			SyncPeriod:        cfg.ResyncPeriod,
 			DefaultNamespaces: defaultNamespaces,
+			DefaultTransform:  cache.TransformStripManagedFields(),
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
To reduce memory consumption, managed fields (managed by API server) get removed from cached objects. Documentation: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/cache#TransformStripManagedFields