### PR TITLE
Add configuration class command-line option

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -26,6 +26,7 @@ The following command-line options are supported:
 | [`--configmap`](#configmap)                             | namespace/configmapname    |                         |       |
 | [`--connection-timeout`](#timeout)                      | duration                   | `30s`                   | v0.14.11 |
 | [`--controller-class`](#ingress-class)                  | suffix                     | `""`                    | v0.12 |
+| [`--configuration-class`](#configuration-class)         | name                       | `""`                    | v0.17 |
 | [`--default-backend-service`](#default-backend-service) | namespace/servicename      | haproxy's 404 page      |       |
 | [`--default-ssl-certificate`](#default-ssl-certificate) | namespace/secretname       | fake, auto generated    |       |
 | [`--disable-api-warnings`](#disable-api-warnings)       | [true\|false]              | `false`                 | v0.12 |
@@ -186,6 +187,19 @@ silently fail.  Version 0.13 and later will crash if the ConfigMap is unreadable
 See also:
 
 * [custom-configuration example using `--configmap`](https://github.com/jcmoraisjr/haproxy-ingress/blob/master/examples/custom-configuration/README.md)
+
+### configuration-class
+
+* `--configuration-class`
+
+Defines the name of an additional class to route through this controller. Ingress or Gateway API resources using this class name are added to the final HAProxy configuration.
+
+This option merges the configuration of the additional class with the primary configuration defined via `--ingress-class` and `--controller-class` options. This is however a "read only" option: Ingress and Gateway API resources using this additional class are added to the HAProxy configuration, but their status are not updated, which avoids conflict with other controller sharing this same class.
+
+See also:
+
+* [Ingress and Gateway API class](#ingress-class)
+* [Migration guide]({{% relref "migration-guide" %}})
 
 ---
 

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -561,6 +561,7 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 		BackendShards:            opt.BackendShards,
 		BucketsResponseTime:      opt.BucketsResponseTime,
 		ConfigMapName:            opt.ConfigMap,
+		ConfigurationClass:       opt.ConfigurationClass,
 		ConnectionTimeout:        opt.ConnectionTimeout,
 		ControllerName:           controllerName,
 		ControllerPod:            controllerPod,
@@ -884,6 +885,7 @@ type Config struct {
 	BackendShards            int
 	BucketsResponseTime      []float64
 	ConfigMapName            string
+	ConfigurationClass       string
 	ConnectionTimeout        time.Duration
 	ControllerName           string
 	ControllerPod            types.NamespacedName

--- a/pkg/controller/config/options.go
+++ b/pkg/controller/config/options.go
@@ -54,6 +54,7 @@ type Options struct {
 	DefaultSvc               string
 	IngressClass             string
 	IngressClassPrecedence   bool
+	ConfigurationClass       string
 	DisableIngressClassAPI   bool
 	ReloadStrategy           string
 	MaxOldConfigFiles        int
@@ -166,6 +167,12 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 
 	fs.StringVar(&o.IngressClass, "ingress-class", o.IngressClass, ""+
 		"Name of the IngressClass to route through this controller.",
+	)
+
+	fs.StringVar(&o.ConfigurationClass, "configuration-class", o.ConfigurationClass, ""+
+		"Name of an additional class to route through this controller. Ingress or "+
+		"Gateway API resources using this class name are added to the final "+
+		"configuration, but their status are not updated.",
 	)
 
 	fs.BoolVar(&o.IngressClassPrecedence, "ingress-class-precedence", o.IngressClassPrecedence, ""+

--- a/pkg/controller/services/cache.go
+++ b/pkg/controller/services/cache.go
@@ -126,9 +126,9 @@ func (c *c) IsValidIngress(ing *networking.Ingress) bool {
 	var ann string
 	ann, hasAnn = ing.Annotations["kubernetes.io/ingress.class"]
 	if c.config.WatchIngressWithoutClass {
-		fromAnn = !hasAnn || ann == c.config.IngressClass
+		fromAnn = !hasAnn || ann == c.config.IngressClass || ann == c.config.ConfigurationClass
 	} else {
-		fromAnn = hasAnn && ann == c.config.IngressClass
+		fromAnn = hasAnn && (ann == c.config.IngressClass || ann == c.config.ConfigurationClass)
 	}
 
 	// check if ingress `hasClass` and, if so, if it's valid `fromClass` perspective
@@ -171,7 +171,8 @@ func (c *c) IsValidIngress(ing *networking.Ingress) bool {
 }
 
 func (c *c) IsValidIngressClass(ingressClass *networking.IngressClass) bool {
-	return ingressClass.Spec.Controller == c.config.ControllerName
+	return ingressClass.Spec.Controller == c.config.ControllerName || // regular check via controller name
+		ingressClass.Name == c.config.ConfigurationClass // extra check via configuration class override
 }
 
 func (c *c) IsValidGateway(gateway *gatewayv1.Gateway) bool {
@@ -199,7 +200,8 @@ func (c *c) IsValidGateway(gateway *gatewayv1.Gateway) bool {
 }
 
 func (c *c) IsValidGatewayClass(class *gatewayv1.GatewayClass) bool {
-	return class.Spec.ControllerName == gatewayv1.GatewayController(c.config.ControllerName)
+	return class.Spec.ControllerName == gatewayv1.GatewayController(c.config.ControllerName) || // regular check via controller name
+		class.Name == c.config.ConfigurationClass // extra check via configuration class override
 }
 
 func (c *c) ExternalNameLookup(externalName string) ([]net.IP, error) {

--- a/pkg/controller/services/svcaddress.go
+++ b/pkg/controller/services/svcaddress.go
@@ -138,6 +138,9 @@ func (s *svcAddress) updateIngressStatus(namespace, name string, lb []networking
 	ing.Namespace = namespace
 	ing.Name = name
 	return s.updateStatus(ing, func() bool {
+		if class := ing.Spec.IngressClassName; class != nil && *class == s.cfg.ConfigurationClass {
+			return false
+		}
 		if reflect.DeepEqual(ing.Status.LoadBalancer.Ingress, lb) {
 			return false
 		}
@@ -151,6 +154,9 @@ func (s *svcAddress) updateGatewayStatus(namespace, name string, lb []gatewayv1.
 	gw.Namespace = namespace
 	gw.Name = name
 	return s.updateStatus(gw, func() bool {
+		if gw.Spec.GatewayClassName == gatewayv1.ObjectName(s.cfg.ConfigurationClass) {
+			return false
+		}
 		if reflect.DeepEqual(gw.Status.Addresses, lb) {
 			return false
 		}


### PR DESCRIPTION
Add the `--configuration-class` command-line option as a helper for the migration process. It allows to listen to a second Ingress or Gateway API class, along with the primary one, without changing the status of the tracking resources.